### PR TITLE
Build FocusFlow to-do experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FocusFlow — Ultimate To‑Do List</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="app-title">
+        <svg
+          class="app-logo"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M9.354 18.354a.5.5 0 0 1-.708 0l-4-4a.5.5 0 1 1 .708-.708L9 17.293l9.646-9.647a.5.5 0 0 1 .708.708l-10 10Z"
+          />
+        </svg>
+        <div>
+          <p class="app-name">FocusFlow</p>
+          <p class="app-tagline">Plan smart. Execute brilliantly.</p>
+        </div>
+      </div>
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle color theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌞</span>
+      </button>
+    </header>
+
+    <main class="app-main">
+      <section class="panel" aria-labelledby="planner-heading">
+        <div class="panel__header">
+          <h1 id="planner-heading">Today's Game Plan</h1>
+          <div class="stats" aria-live="polite">
+            <span id="stats-total" class="stats__item">0 tasks</span>
+            <span id="stats-completed" class="stats__item">0 completed</span>
+          </div>
+        </div>
+
+        <form id="task-form" class="task-form" autocomplete="off">
+          <div class="task-form__main">
+            <label class="field">
+              <span class="field__label">Task</span>
+              <input
+                id="task-title"
+                name="title"
+                type="text"
+                placeholder="What needs to get done?"
+                required
+                maxlength="120"
+              />
+            </label>
+
+            <label class="field">
+              <span class="field__label">Details</span>
+              <textarea
+                id="task-description"
+                name="description"
+                placeholder="Add helpful context, links, or notes"
+                rows="2"
+                maxlength="400"
+              ></textarea>
+            </label>
+          </div>
+
+          <div class="task-form__meta">
+            <label class="field">
+              <span class="field__label">Due date</span>
+              <input id="task-due" name="dueDate" type="date" />
+            </label>
+
+            <label class="field">
+              <span class="field__label">Priority</span>
+              <select id="task-priority" name="priority">
+                <option value="medium" selected>Medium</option>
+                <option value="high">High</option>
+                <option value="low">Low</option>
+              </select>
+            </label>
+
+            <div class="task-form__actions">
+              <button type="reset" class="btn btn--ghost" id="cancel-edit" hidden>
+                Cancel
+              </button>
+              <button type="submit" class="btn" id="submit-button">Add task</button>
+            </div>
+          </div>
+        </form>
+
+        <div class="toolbar" role="region" aria-label="Task controls">
+          <div class="toolbar__group">
+            <label class="search" for="search-input">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  d="M10.5 4a6.5 6.5 0 0 1 5.126 10.5l3.437 3.437a1 1 0 0 1-1.414 1.414l-3.437-3.437A6.5 6.5 0 1 1 10.5 4Zm0 2a4.5 4.5 0 1 0 0 9 4.5 4.5 0 0 0 0-9Z"
+                />
+              </svg>
+              <input
+                id="search-input"
+                type="search"
+                placeholder="Search tasks"
+                aria-label="Search tasks"
+              />
+            </label>
+          </div>
+
+          <div class="toolbar__group toolbar__group--filters">
+            <div class="filter">
+              <label for="status-filter">Status</label>
+              <select id="status-filter">
+                <option value="all">All</option>
+                <option value="active">Active</option>
+                <option value="completed">Completed</option>
+              </select>
+            </div>
+
+            <div class="filter">
+              <label for="priority-filter">Priority</label>
+              <select id="priority-filter">
+                <option value="all">All</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+
+            <div class="filter">
+              <label for="schedule-filter">Schedule</label>
+              <select id="schedule-filter">
+                <option value="all">Anytime</option>
+                <option value="overdue">Overdue</option>
+                <option value="today">Due today</option>
+                <option value="upcoming">Upcoming</option>
+              </select>
+            </div>
+
+            <div class="filter">
+              <label for="sort-select">Sort by</label>
+              <select id="sort-select">
+                <option value="created">Recently added</option>
+                <option value="due">Due date</option>
+                <option value="priority">Priority</option>
+                <option value="title">Title</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="toolbar__group toolbar__group--actions">
+            <button class="btn btn--ghost" type="button" id="clear-completed">
+              Clear completed
+            </button>
+            <button class="btn btn--ghost" type="button" id="complete-all">
+              Complete all
+            </button>
+            <button class="btn btn--ghost" type="button" id="export-button">
+              Export
+            </button>
+          </div>
+        </div>
+
+        <div class="progress" role="img" aria-label="Task completion progress">
+          <div class="progress__bar" id="progress-bar"></div>
+        </div>
+
+        <ul id="task-list" class="task-list" aria-live="polite" aria-label="To do list">
+          <!-- tasks injected via template -->
+        </ul>
+
+        <p class="empty-state" id="empty-state" hidden>
+          Your list is clear. Add something you want to conquer today.
+        </p>
+      </section>
+    </main>
+
+    <template id="task-template">
+      <li class="task" data-id="">
+        <label class="task__checkbox">
+          <input type="checkbox" class="task__toggle" />
+          <span class="task__indicator" aria-hidden="true"></span>
+        </label>
+        <div class="task__content">
+          <div class="task__header">
+            <p class="task__title"></p>
+            <span class="task__badge task__badge--priority"></span>
+          </div>
+          <p class="task__description"></p>
+          <ul class="task__meta"></ul>
+        </div>
+        <div class="task__actions">
+          <button type="button" class="icon-button task__edit" aria-label="Edit task">
+            ✏️
+          </button>
+          <button type="button" class="icon-button task__delete" aria-label="Delete task">
+            🗑️
+          </button>
+        </div>
+      </li>
+    </template>
+
+    <dialog id="export-dialog">
+      <form method="dialog">
+        <h2>Export your plan</h2>
+        <p>
+          Copy the generated text below to share your progress or keep a backup.
+        </p>
+        <textarea id="export-text" readonly></textarea>
+        <div class="dialog-actions">
+          <button value="cancel" class="btn btn--ghost">Close</button>
+          <button
+            id="copy-export"
+            class="btn"
+            type="button"
+            data-feedback="Copied!"
+          >
+            Copy
+          </button>
+        </div>
+      </form>
+    </dialog>
+
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,552 @@
+const STORAGE_KEY = 'focusflow.tasks.v1';
+const THEME_KEY = 'focusflow.theme';
+
+const form = document.getElementById('task-form');
+const titleInput = document.getElementById('task-title');
+const descriptionInput = document.getElementById('task-description');
+const dueInput = document.getElementById('task-due');
+const prioritySelect = document.getElementById('task-priority');
+const cancelEditButton = document.getElementById('cancel-edit');
+const submitButton = document.getElementById('submit-button');
+const taskList = document.getElementById('task-list');
+const emptyState = document.getElementById('empty-state');
+const statsTotal = document.getElementById('stats-total');
+const statsCompleted = document.getElementById('stats-completed');
+const progressBar = document.getElementById('progress-bar');
+const searchInput = document.getElementById('search-input');
+const statusFilter = document.getElementById('status-filter');
+const priorityFilter = document.getElementById('priority-filter');
+const scheduleFilter = document.getElementById('schedule-filter');
+const sortSelect = document.getElementById('sort-select');
+const clearCompletedButton = document.getElementById('clear-completed');
+const completeAllButton = document.getElementById('complete-all');
+const exportButton = document.getElementById('export-button');
+const exportDialog = document.getElementById('export-dialog');
+const exportText = document.getElementById('export-text');
+const copyExportButton = document.getElementById('copy-export');
+const themeToggle = document.getElementById('theme-toggle');
+const themeToggleIcon = themeToggle.querySelector('.theme-toggle__icon');
+
+const state = {
+  tasks: loadTasks(),
+  editingId: null,
+  filters: {
+    search: '',
+    status: 'all',
+    priority: 'all',
+    schedule: 'all',
+    sort: 'created',
+  },
+};
+
+const PRIORITY_ORDER = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+const formatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  weekday: 'short',
+});
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function loadTasks() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((task) => ({
+      ...task,
+      createdAt: task.createdAt || new Date().toISOString(),
+    }));
+  } catch (error) {
+    console.warn('Failed to parse saved tasks', error);
+    return [];
+  }
+}
+
+function persistTasks() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.tasks));
+  } catch (error) {
+    console.warn('Unable to persist tasks', error);
+  }
+}
+
+function loadTheme() {
+  const stored = localStorage.getItem(THEME_KEY);
+  if (stored === 'dark' || stored === 'light') {
+    applyTheme(stored);
+    return;
+  }
+
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  applyTheme(prefersDark ? 'dark' : 'light');
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem(THEME_KEY, theme);
+  themeToggleIcon.textContent = theme === 'dark' ? '🌙' : '🌞';
+  themeToggle.setAttribute('aria-label', `Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`);
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme') || 'light';
+  applyTheme(current === 'light' ? 'dark' : 'light');
+}
+
+function createTask(data) {
+  const task = {
+    id: generateId(),
+    title: data.title.trim(),
+    description: data.description.trim(),
+    dueDate: data.dueDate ? data.dueDate : null,
+    priority: data.priority,
+    completed: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  state.tasks = [task, ...state.tasks];
+  persistTasks();
+  announce(`Added "${task.title}" to your plan.`);
+  render();
+}
+
+function updateTask(id, changes) {
+  state.tasks = state.tasks.map((task) =>
+    task.id === id
+      ? {
+          ...task,
+          ...changes,
+        }
+      : task
+  );
+  persistTasks();
+  render();
+}
+
+function deleteTask(id) {
+  const task = state.tasks.find((item) => item.id === id);
+  state.tasks = state.tasks.filter((task) => task.id !== id);
+  persistTasks();
+  if (task) {
+    announce(`Removed "${task.title}" from the list.`);
+  }
+  render();
+}
+
+function announce(message) {
+  const liveRegion = document.createElement('div');
+  liveRegion.setAttribute('role', 'status');
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.className = 'sr-only';
+  liveRegion.textContent = message;
+  document.body.appendChild(liveRegion);
+  requestAnimationFrame(() => {
+    document.body.removeChild(liveRegion);
+  });
+}
+
+function resetForm() {
+  state.editingId = null;
+  submitButton.textContent = 'Add task';
+  cancelEditButton.hidden = true;
+  form.reset();
+  titleInput.focus();
+}
+
+function beginEdit(task) {
+  state.editingId = task.id;
+  titleInput.value = task.title;
+  descriptionInput.value = task.description;
+  dueInput.value = task.dueDate ?? '';
+  prioritySelect.value = task.priority;
+  submitButton.textContent = 'Save changes';
+  cancelEditButton.hidden = false;
+  titleInput.focus();
+  announce(`Editing "${task.title}"`);
+}
+
+function isOverdue(task) {
+  if (!task.dueDate) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(task.dueDate);
+  due.setHours(0, 0, 0, 0);
+  return due < today && !task.completed;
+}
+
+function isDueToday(task) {
+  if (!task.dueDate) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(task.dueDate);
+  due.setHours(0, 0, 0, 0);
+  return due.getTime() === today.getTime();
+}
+
+function isUpcoming(task) {
+  if (!task.dueDate) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(task.dueDate);
+  due.setHours(0, 0, 0, 0);
+  return due > today;
+}
+
+function applyFilters(tasks) {
+  let filtered = [...tasks];
+
+  const { search, status, priority, schedule } = state.filters;
+  if (search) {
+    const q = search.toLowerCase();
+    filtered = filtered.filter(
+      (task) =>
+        task.title.toLowerCase().includes(q) ||
+        task.description.toLowerCase().includes(q)
+    );
+  }
+
+  if (status !== 'all') {
+    filtered = filtered.filter((task) =>
+      status === 'completed' ? task.completed : !task.completed
+    );
+  }
+
+  if (priority !== 'all') {
+    filtered = filtered.filter((task) => task.priority === priority);
+  }
+
+  if (schedule !== 'all') {
+    filtered = filtered.filter((task) => {
+      switch (schedule) {
+        case 'overdue':
+          return isOverdue(task);
+        case 'today':
+          return isDueToday(task);
+        case 'upcoming':
+          return isUpcoming(task);
+        default:
+          return true;
+      }
+    });
+  }
+
+  return sortTasks(filtered);
+}
+
+function sortTasks(tasks) {
+  const { sort } = state.filters;
+  const copy = [...tasks];
+  switch (sort) {
+    case 'due':
+      return copy.sort((a, b) => {
+        if (!a.dueDate && !b.dueDate) return compareCreated(b, a);
+        if (!a.dueDate) return 1;
+        if (!b.dueDate) return -1;
+        const diff = new Date(a.dueDate) - new Date(b.dueDate);
+        if (diff !== 0) return diff;
+        return compareCreated(b, a);
+      });
+    case 'priority':
+      return copy.sort((a, b) => {
+        const diff = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
+        if (diff !== 0) return diff;
+        return compareCreated(b, a);
+      });
+    case 'title':
+      return copy.sort((a, b) => a.title.localeCompare(b.title));
+    case 'created':
+    default:
+      return copy.sort(compareCreated);
+  }
+}
+
+function compareCreated(a, b) {
+  return new Date(b.createdAt) - new Date(a.createdAt);
+}
+
+function updateStats(tasks) {
+  const total = tasks.length;
+  const completed = tasks.filter((task) => task.completed).length;
+  statsTotal.textContent = `${total} ${total === 1 ? 'task' : 'tasks'}`;
+  statsCompleted.textContent = `${completed} completed`;
+  progressBar.style.width = total === 0 ? '0%' : `${(completed / total) * 100}%`;
+}
+
+function render() {
+  const filteredTasks = applyFilters(state.tasks);
+  taskList.innerHTML = '';
+
+  filteredTasks.forEach((task) => {
+    const node = renderTask(task);
+    taskList.appendChild(node);
+  });
+
+  emptyState.hidden = filteredTasks.length !== 0;
+  updateStats(state.tasks);
+}
+
+function renderTask(task) {
+  const template = document.getElementById('task-template');
+  const clone = template.content.firstElementChild.cloneNode(true);
+  clone.dataset.id = task.id;
+
+  const toggle = clone.querySelector('.task__toggle');
+  toggle.checked = task.completed;
+
+  const content = clone.querySelector('.task__content');
+  const titleEl = clone.querySelector('.task__title');
+  titleEl.textContent = task.title;
+
+  if (task.completed) {
+    clone.classList.add('task--completed');
+  }
+
+  const descriptionEl = clone.querySelector('.task__description');
+  if (task.description) {
+    descriptionEl.textContent = task.description;
+    descriptionEl.hidden = false;
+  } else {
+    descriptionEl.hidden = true;
+  }
+
+  const priorityBadge = clone.querySelector('.task__badge--priority');
+  priorityBadge.dataset.priority = task.priority;
+  priorityBadge.textContent = `${task.priority} priority`;
+
+  const metaList = clone.querySelector('.task__meta');
+  metaList.innerHTML = '';
+
+  if (task.dueDate) {
+    const dueItem = document.createElement('li');
+    dueItem.className = 'task__badge task__badge--due';
+    dueItem.textContent = `Due ${formatter.format(new Date(task.dueDate))}`;
+    if (isOverdue(task)) {
+      dueItem.classList.add('task__badge--overdue');
+      dueItem.textContent = `Overdue — ${formatter.format(new Date(task.dueDate))}`;
+    } else if (isDueToday(task)) {
+      dueItem.textContent = `Due today (${formatter.format(new Date(task.dueDate))})`;
+    }
+    metaList.appendChild(dueItem);
+  }
+
+  const createdItem = document.createElement('li');
+  createdItem.className = 'task__badge';
+  createdItem.textContent = `Added ${timeAgo(new Date(task.createdAt))}`;
+  metaList.appendChild(createdItem);
+
+  if (task.completed) {
+    const completedItem = document.createElement('li');
+    completedItem.className = 'task__badge task__badge--completed';
+    completedItem.textContent = 'Completed';
+    metaList.appendChild(completedItem);
+  }
+
+  return clone;
+}
+
+function timeAgo(date) {
+  const now = new Date();
+  const diff = now - date;
+  const minutes = Math.round(diff / (1000 * 60));
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return `${minutes} minutes ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours === 1) return '1 hour ago';
+  if (hours < 24) return `${hours} hours ago`;
+  const days = Math.round(hours / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days} days ago`;
+  return formatter.format(date);
+}
+
+function exportTasks() {
+  const lines = state.tasks.map((task, index) => {
+    const parts = [`${index + 1}. ${task.title}`];
+    parts.push(`Status: ${task.completed ? '✅ Completed' : '⭕ Active'}`);
+    parts.push(`Priority: ${task.priority}`);
+    if (task.dueDate) {
+      parts.push(`Due: ${formatter.format(new Date(task.dueDate))}`);
+    }
+    parts.push(`Created: ${new Date(task.createdAt).toLocaleString()}`);
+    if (task.description) {
+      parts.push(`Notes: ${task.description}`);
+    }
+    return parts.join('\n');
+  });
+
+  exportText.value = lines.join('\n\n');
+  exportDialog.showModal();
+}
+
+async function copyExport() {
+  try {
+    await navigator.clipboard.writeText(exportText.value);
+    const original = copyExportButton.textContent;
+    const feedback = copyExportButton.dataset.feedback || 'Copied!';
+    copyExportButton.textContent = feedback;
+    setTimeout(() => {
+      copyExportButton.textContent = original;
+    }, 1200);
+  } catch (error) {
+    console.warn('Clipboard copy failed', error);
+  }
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const data = new FormData(form);
+  const title = data.get('title').trim();
+  if (!title) {
+    titleInput.focus();
+    return;
+  }
+
+  const payload = {
+    title,
+    description: data.get('description')?.trim() ?? '',
+    dueDate: data.get('dueDate') || null,
+    priority: data.get('priority') || 'medium',
+  };
+
+  if (state.editingId) {
+    updateTask(state.editingId, payload);
+    announce(`Saved changes to "${payload.title}"`);
+  } else {
+    createTask(payload);
+  }
+
+  resetForm();
+});
+
+cancelEditButton.addEventListener('click', (event) => {
+  event.preventDefault();
+  resetForm();
+});
+
+searchInput.addEventListener('input', (event) => {
+  state.filters.search = event.target.value;
+  render();
+});
+
+statusFilter.addEventListener('change', (event) => {
+  state.filters.status = event.target.value;
+  render();
+});
+
+priorityFilter.addEventListener('change', (event) => {
+  state.filters.priority = event.target.value;
+  render();
+});
+
+scheduleFilter.addEventListener('change', (event) => {
+  state.filters.schedule = event.target.value;
+  render();
+});
+
+sortSelect.addEventListener('change', (event) => {
+  state.filters.sort = event.target.value;
+  render();
+});
+
+taskList.addEventListener('click', (event) => {
+  const target = event.target;
+  const item = target.closest('.task');
+  if (!item) return;
+  const id = item.dataset.id;
+  if (!id) return;
+
+  if (target.matches('.task__delete')) {
+    deleteTask(id);
+    return;
+  }
+
+  if (target.matches('.task__edit')) {
+    const task = state.tasks.find((t) => t.id === id);
+    if (task) {
+      beginEdit(task);
+    }
+    return;
+  }
+});
+
+// handle checkbox change due to label click bubbling
+taskList.addEventListener('change', (event) => {
+  const target = event.target;
+  if (!target.matches('.task__toggle')) return;
+  const item = target.closest('.task');
+  const id = item?.dataset.id;
+  if (!id) return;
+  updateTask(id, { completed: target.checked });
+});
+
+clearCompletedButton.addEventListener('click', () => {
+  const completed = state.tasks.filter((task) => task.completed).length;
+  if (!completed) return;
+  state.tasks = state.tasks.filter((task) => !task.completed);
+  persistTasks();
+  announce(`Cleared ${completed} completed ${completed === 1 ? 'task' : 'tasks'}.`);
+  render();
+});
+
+completeAllButton.addEventListener('click', () => {
+  const allComplete = state.tasks.every((task) => task.completed);
+  state.tasks = state.tasks.map((task) => ({ ...task, completed: !allComplete }));
+  persistTasks();
+  announce(allComplete ? 'Reset all tasks to active.' : 'Marked every task complete.');
+  render();
+});
+
+exportButton.addEventListener('click', () => {
+  exportTasks();
+});
+
+copyExportButton.addEventListener('click', () => {
+  copyExport();
+});
+
+themeToggle.addEventListener('click', toggleTheme);
+
+exportDialog.addEventListener('cancel', () => {
+  exportDialog.close();
+});
+
+exportDialog.addEventListener('click', (event) => {
+  const rect = exportDialog.getBoundingClientRect();
+  const isInDialog =
+    event.clientX >= rect.left &&
+    event.clientX <= rect.right &&
+    event.clientY >= rect.top &&
+    event.clientY <= rect.bottom;
+  if (!isInDialog) {
+    exportDialog.close();
+  }
+});
+
+window.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && state.editingId) {
+    resetForm();
+  }
+});
+
+function init() {
+  loadTheme();
+  render();
+  if (state.tasks.length === 0) {
+    titleInput.focus();
+  }
+}
+
+init();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,570 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --surface-alt: #f0f2f8;
+  --text: #1a1f36;
+  --text-secondary: #4a4f65;
+  --accent: #4f46e5;
+  --accent-strong: #3730a3;
+  --border: rgba(42, 50, 80, 0.12);
+  --border-strong: rgba(42, 50, 80, 0.2);
+  --shadow: 0 20px 30px -16px rgba(15, 23, 42, 0.3);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 16px;
+}
+
+[data-theme='dark'] {
+  --bg: #0f172a;
+  --surface: #111c34;
+  --surface-alt: #14213d;
+  --text: #f1f5f9;
+  --text-secondary: #cbd5f5;
+  --accent: #38bdf8;
+  --accent-strong: #0284c7;
+  --border: rgba(148, 163, 184, 0.2);
+  --border-strong: rgba(148, 163, 184, 0.4);
+  --shadow: 0 22px 50px -20px rgba(9, 17, 34, 0.8);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(1.5rem, 4vw, 2.5rem) clamp(1.5rem, 4vw, 3rem) 0;
+}
+
+.app-title {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-logo {
+  width: 2.6rem;
+  height: 2.6rem;
+  fill: var(--accent);
+  filter: drop-shadow(0 8px 16px rgba(79, 70, 229, 0.35));
+}
+
+.app-name {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.app-tagline {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin: 0.15rem 0 0;
+}
+
+.theme-toggle {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 1.25rem;
+  padding: 0.35rem 0.8rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px -20px rgba(15, 23, 42, 0.45);
+}
+
+.app-main {
+  display: flex;
+  justify-content: center;
+  padding: clamp(0.5rem, 2vw, 1.5rem);
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: var(--shadow);
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.panel__header h1 {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  margin: 0;
+}
+
+.stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.stats__item {
+  background: var(--surface-alt);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+}
+
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  background: linear-gradient(
+      145deg,
+      rgba(79, 70, 229, 0.08),
+      rgba(79, 70, 229, 0.02)
+    ),
+    var(--surface);
+}
+
+.task-form__main {
+  display: grid;
+  gap: 1rem;
+}
+
+.task-form__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.task-form__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 220px;
+  gap: 0.35rem;
+}
+
+.field__label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+input,
+textarea,
+select {
+  font: inherit;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 0.75rem 1rem;
+  color: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  resize: none;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+
+.btn {
+  font: inherit;
+  border-radius: 12px;
+  border: none;
+  padding: 0.75rem 1.4rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 24px -18px rgba(79, 70, 229, 0.55);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.btn--ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: none;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1rem;
+  background: var(--surface-alt);
+}
+
+.toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.toolbar__group--filters {
+  flex: 1 1 360px;
+  justify-content: flex-end;
+}
+
+.toolbar__group--actions {
+  justify-content: flex-end;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 14px;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.search input {
+  border: none;
+  padding: 0;
+  background: transparent;
+  min-width: 180px;
+}
+
+.search svg {
+  width: 1rem;
+  fill: var(--text-secondary);
+}
+
+.filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+}
+
+.filter select {
+  min-width: 140px;
+  font-size: 0.95rem;
+}
+
+.progress {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--surface-alt);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.progress__bar {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  transition: width 0.4s ease;
+}
+
+.task-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.task {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.task:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.task__checkbox {
+  position: relative;
+  width: 24px;
+  height: 24px;
+}
+
+.task__checkbox input {
+  position: absolute;
+  opacity: 0;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  margin: 0;
+}
+
+.task__indicator {
+  display: block;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  border: 2px solid var(--border-strong);
+  background: var(--surface);
+  transition: all 0.2s ease;
+}
+
+.task__checkbox input:checked + .task__indicator {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 10px 25px -15px rgba(79, 70, 229, 0.7);
+}
+
+.task__checkbox input:checked + .task__indicator::after {
+  content: '✓';
+  display: block;
+  text-align: center;
+  color: white;
+  font-weight: 700;
+  transform: translateY(1px);
+}
+
+.task__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.task__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.task__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.task--completed .task__title {
+  text-decoration: line-through;
+  color: var(--text-secondary);
+}
+
+.task__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  white-space: pre-line;
+}
+
+.task__meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.task__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  background: rgba(79, 70, 229, 0.15);
+  color: var(--accent-strong);
+}
+
+.task__badge--due {
+  background: rgba(8, 145, 178, 0.15);
+  color: #0f766e;
+}
+
+.task__badge--overdue {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.task__badge--completed {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.task__badge--priority[data-priority='high'] {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.task__badge--priority[data-priority='medium'] {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.task__badge--priority[data-priority='low'] {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.task__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.icon-button {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 0.25rem;
+  transition: transform 0.2s ease;
+}
+
+.icon-button:hover {
+  transform: scale(1.1);
+}
+
+.empty-state {
+  margin: 0;
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--text-secondary);
+  border: 2px dashed var(--border);
+  border-radius: 18px;
+}
+
+#export-dialog {
+  border: none;
+  border-radius: 16px;
+  padding: 1.75rem;
+  max-width: 420px;
+  width: 90vw;
+  background: var(--surface);
+  color: var(--text);
+}
+
+#export-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+#export-text {
+  width: 100%;
+  min-height: 160px;
+  margin-top: 1rem;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: inherit;
+  resize: vertical;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 768px) {
+  .toolbar__group--filters,
+  .toolbar__group--actions {
+    justify-content: flex-start;
+  }
+
+  .task {
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      'checkbox header'
+      'checkbox description'
+      'checkbox meta'
+      'checkbox actions';
+  }
+
+  .task__content {
+    grid-area: header;
+  }
+
+  .task__actions {
+    grid-area: actions;
+    flex-direction: row;
+  }
+}
+
+@media (max-width: 540px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar__group,
+  .task-form__meta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search input {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- create a FocusFlow single-page to-do workspace with rich task inputs, filter controls, progress, and export tooling
- implement client-side logic for task CRUD, filtering, sorting, stats, clipboard export, and theme persistence in localStorage
- design polished responsive styling with dark mode, gradients, and accessibility helpers

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d128f7310c832e878ffefe660a998f