### PR TITLE
Handle local due dates correctly

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -59,4 +59,38 @@ describe('App task flow', () => {
 
     expect(screen.getByText('Stored Task')).toBeInTheDocument();
   });
+
+  it('displays the entered due date for plain date inputs in a negative offset timezone', async () => {
+    const originalTZ = process.env.TZ;
+
+    try {
+      process.env.TZ = 'America/Los_Angeles';
+
+      await renderApp();
+
+      const input = screen.getByLabelText(/What needs to be done/i);
+      fireEvent.change(input, { target: { value: 'Task with due date' } });
+
+      const dueDateInput = screen.getByLabelText(/Due date/i);
+      fireEvent.change(dueDateInput, { target: { value: '2024-04-10' } });
+
+      const addButton = screen.getByRole('button', { name: /Add task/i });
+      fireEvent.click(addButton);
+
+      const expectedDueDate = new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }).format(new Date(2024, 3, 10));
+
+      expect(screen.getByText('Task with due date')).toBeInTheDocument();
+      expect(screen.getByText(expectedDueDate)).toBeInTheDocument();
+    } finally {
+      if (originalTZ === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTZ;
+      }
+    }
+  });
 });

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -10,7 +10,16 @@ type TaskItemProps = {
 
 const formatDate = (value?: string | null) => {
   if (!value) return null;
-  const date = new Date(value);
+
+  const plainDateMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  const date = plainDateMatch
+    ? new Date(
+        Number(plainDateMatch[1]),
+        Number(plainDateMatch[2]) - 1,
+        Number(plainDateMatch[3])
+      )
+    : new Date(value);
+
   if (Number.isNaN(date.getTime())) return null;
   return new Intl.DateTimeFormat(undefined, {
     month: 'short',

--- a/src/store/useTasks.ts
+++ b/src/store/useTasks.ts
@@ -38,12 +38,15 @@ export const useTasks = create<TaskState>((set) => ({
       return;
     }
 
+    const normalizedDueDate =
+      typeof dueDate === 'string' && dueDate.trim() !== '' ? dueDate : null;
+
     const newTask: Task = {
       id: nanoid(),
       title: trimmed,
       completed: false,
       createdAt: new Date().toISOString(),
-      dueDate: dueDate ? new Date(dueDate).toISOString() : null,
+      dueDate: normalizedDueDate,
     };
 
     set((state) => ({ tasks: [newTask, ...state.tasks] }));


### PR DESCRIPTION
## Summary
- keep task due dates as entered instead of coercing them to UTC
- detect plain YYYY-MM-DD strings when formatting dates so local timezones are honored
- add a unit test that verifies due dates render correctly in a negative offset timezone

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d223aec9c8832e81f947dc515f34a5